### PR TITLE
Address feedback from customers

### DIFF
--- a/qldbdriver/qldbdriver_test.go
+++ b/qldbdriver/qldbdriver_test.go
@@ -508,7 +508,7 @@ func TestGetTableNames(t *testing.T) {
 	})
 }
 
-func TestCloseDriver(t *testing.T) {
+func TestShutdownDriver(t *testing.T) {
 	testDriver := QLDBDriver{
 		ledgerName:                mockLedgerName,
 		qldbSession:               nil,
@@ -525,7 +525,7 @@ func TestCloseDriver(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
-		testDriver.Close(context.Background())
+		testDriver.Shutdown(context.Background())
 		assert.Equal(t, testDriver.isClosed, true)
 		_, ok := <-testDriver.sessionPool
 		assert.Equal(t, ok, false)
@@ -548,7 +548,7 @@ func TestGetSession(t *testing.T) {
 				SleepBase: time.Duration(10) * time.Millisecond,
 				SleepCap:  time.Duration(5000) * time.Millisecond}},
 	}
-	defer testDriver.Close(context.Background())
+	defer testDriver.Shutdown(context.Background())
 
 	t.Run("error", func(t *testing.T) {
 		mockSession := new(mockQLDBSession)
@@ -613,7 +613,7 @@ func TestSessionPoolCapacity(t *testing.T) {
 					SleepBase: time.Duration(10) * time.Millisecond,
 					SleepCap:  time.Duration(5000) * time.Millisecond}},
 		}
-		defer testDriver.Close(context.Background())
+		defer testDriver.Shutdown(context.Background())
 
 		mockSession := new(mockQLDBSession)
 		mockSession.On("SendCommandWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&mockDriverSendCommand, nil)

--- a/qldbdriver/session_management_test.go
+++ b/qldbdriver/session_management_test.go
@@ -40,7 +40,7 @@ func TestSessionManagementIntegration(t *testing.T) {
 	t.Run("Fail connecting to non existent ledger", func(t *testing.T) {
 		driver, err := testBase.getDriver("NoSuchALedger", 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 
 		_, err = driver.GetTableNames(context.Background())
 		require.Error(t, err)
@@ -53,7 +53,7 @@ func TestSessionManagementIntegration(t *testing.T) {
 	t.Run("Get session when pool doesnt have session and has not hit limit", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 
 		result, err := driver.GetTableNames(context.Background())
 		assert.NoError(t, err)
@@ -63,7 +63,7 @@ func TestSessionManagementIntegration(t *testing.T) {
 	t.Run("Get session when pool has session and has not hit limit", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 
 		result, err := driver.GetTableNames(context.Background())
 
@@ -79,7 +79,7 @@ func TestSessionManagementIntegration(t *testing.T) {
 	t.Run("Get session when pool doesnt have session and has hit limit", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 1, 4)
 		require.NoError(t, err)
-		driver.Close(context.Background())
+		driver.Shutdown(context.Background())
 
 		errs, ctx := errgroup.WithContext(context.Background())
 
@@ -103,7 +103,7 @@ func TestSessionManagementIntegration(t *testing.T) {
 	t.Run("Get session when driver is closed", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 1, 4)
 		require.NoError(t, err)
-		driver.Close(context.Background())
+		driver.Shutdown(context.Background())
 
 		_, err = driver.GetTableNames(context.Background())
 		assert.Error(t, err)

--- a/qldbdriver/statement_execution_test.go
+++ b/qldbdriver/statement_execution_test.go
@@ -78,7 +78,7 @@ func TestStatementExecution(t *testing.T) {
 	t.Run("Drop existing table", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 
 		createTableName := "GoIntegrationTestCreateTable"
 		createTableQuery := fmt.Sprintf("CREATE TABLE %s", createTableName)
@@ -105,7 +105,7 @@ func TestStatementExecution(t *testing.T) {
 	t.Run("List tables", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 		defer cleanup(driver, testTableName)
 
 		tables, err := driver.GetTableNames(context.Background())
@@ -116,7 +116,7 @@ func TestStatementExecution(t *testing.T) {
 	t.Run("Create table that exists", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 		defer cleanup(driver, testTableName)
 
 		query := fmt.Sprintf("CREATE TABLE %s", testTableName)
@@ -134,7 +134,7 @@ func TestStatementExecution(t *testing.T) {
 	t.Run("Create index", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 		defer cleanup(driver, testTableName)
 
 		indexQuery := fmt.Sprintf("CREATE INDEX ON %s (%s)", testTableName, indexAttribute)
@@ -173,7 +173,7 @@ func TestStatementExecution(t *testing.T) {
 	t.Run("Return empty when no records found", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 		defer cleanup(driver, testTableName)
 
 		// Note : We are using a select * without specifying a where condition for the purpose of this test.
@@ -189,7 +189,7 @@ func TestStatementExecution(t *testing.T) {
 	t.Run("Insert document", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 		defer cleanup(driver, testTableName)
 
 		type TestTable struct {
@@ -229,7 +229,7 @@ func TestStatementExecution(t *testing.T) {
 	t.Run("Query table enclosed in quotes", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 		defer cleanup(driver, testTableName)
 
 		type TestTable struct {
@@ -269,7 +269,7 @@ func TestStatementExecution(t *testing.T) {
 	t.Run("Insert multiple documents", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 		defer cleanup(driver, testTableName)
 
 		type TestTable struct {
@@ -317,7 +317,7 @@ func TestStatementExecution(t *testing.T) {
 	t.Run("Delete single document", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 		defer cleanup(driver, testTableName)
 
 		type TestTable struct {
@@ -365,7 +365,7 @@ func TestStatementExecution(t *testing.T) {
 	t.Run("Delete all documents", func(t *testing.T) {
 		driver, err := testBase.getDriver(ledger, 10, 4)
 		require.NoError(t, err)
-		defer driver.Close(context.Background())
+		defer driver.Shutdown(context.Background())
 		defer cleanup(driver, testTableName)
 
 		type TestTable struct {
@@ -446,7 +446,7 @@ func TestStatementExecution(t *testing.T) {
 		t.Run("struct", func(t *testing.T) {
 			driver, err := testBase.getDriver(ledger, 10, 4)
 			require.NoError(t, err)
-			defer driver.Close(context.Background())
+			defer driver.Shutdown(context.Background())
 			defer cleanup(driver, testTableName)
 
 			type Anon struct {
@@ -490,7 +490,7 @@ func TestStatementExecution(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 				driver, err := testBase.getDriver(ledger, 10, 4)
 				require.NoError(t, err)
-				defer driver.Close(context.Background())
+				defer driver.Shutdown(context.Background())
 				defer cleanup(driver, testTableName)
 
 				executeResult, executeErr := driver.Execute(context.Background(), func(txn Transaction) (interface{}, error) {
@@ -646,7 +646,7 @@ func TestStatementExecution(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 				driver, err := testBase.getDriver(ledger, 10, 4)
 				require.NoError(t, err)
-				defer driver.Close(context.Background())
+				defer driver.Shutdown(context.Background())
 
 				executeResult, executeErr := driver.Execute(context.Background(), func(txn Transaction) (interface{}, error) {
 					return executeWithParam(context.Background(), inputQuery, txn, parameter)
@@ -765,7 +765,7 @@ func TestStatementExecution(t *testing.T) {
 		t.Run("nil", func(t *testing.T) {
 			driver, err := testBase.getDriver(ledger, 10, 4)
 			require.NoError(t, err)
-			defer driver.Close(context.Background())
+			defer driver.Shutdown(context.Background())
 
 			query := fmt.Sprintf("UPDATE %s SET %s = ?", testTableName, columnName)
 			executeResult, executeErr := driver.Execute(context.Background(), func(txn Transaction) (interface{}, error) {
@@ -798,7 +798,7 @@ func TestStatementExecution(t *testing.T) {
 		t.Run("struct", func(t *testing.T) {
 			driver, err := testBase.getDriver(ledger, 10, 4)
 			require.NoError(t, err)
-			defer driver.Close(context.Background())
+			defer driver.Shutdown(context.Background())
 			defer cleanup(driver, testTableName)
 
 			type Anon struct {
@@ -847,6 +847,6 @@ func TestStatementExecution(t *testing.T) {
 	})
 
 	//teardown
-	qldbDriver.Close(context.Background())
+	qldbDriver.Shutdown(context.Background())
 	testBase.deleteLedger(t)
 }


### PR DESCRIPTION
- Renamed Close to Shutdown to avoid Closer interface
- Removed RetryPolicyContext because RetriedError cannot be used
- Use a lock on Shutdown to prevent concurrency issues