### PR TITLE
Fixed str conversion bug found in Go 1.15

### DIFF
--- a/qldbdriver/session_management_test.go
+++ b/qldbdriver/session_management_test.go
@@ -17,6 +17,7 @@ package qldbdriver
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -85,10 +86,10 @@ func TestSessionManagementIntegration(t *testing.T) {
 
 		for i := 0; i < 3; i++ {
 			errs.Go(func() error {
-				testBase.logger.Log("start " + string(i))
+				testBase.logger.Log("start " + strconv.Itoa(i))
 				_, err := driver.GetTableNames(ctx)
 				time.Sleep(1 * time.Second)
-				testBase.logger.Log("end " + string(i))
+				testBase.logger.Log("end " + strconv.Itoa(i))
 				return err
 			})
 		}

--- a/qldbdriver/session_management_test.go
+++ b/qldbdriver/session_management_test.go
@@ -17,7 +17,6 @@ package qldbdriver
 
 import (
 	"context"
-	"strconv"
 	"testing"
 	"time"
 
@@ -86,10 +85,10 @@ func TestSessionManagementIntegration(t *testing.T) {
 
 		for i := 0; i < 3; i++ {
 			errs.Go(func() error {
-				testBase.logger.Log("start " + strconv.Itoa(i))
+				testBase.logger.Log("start " + string(rune(i)))
 				_, err := driver.GetTableNames(ctx)
 				time.Sleep(1 * time.Second)
-				testBase.logger.Log("end " + strconv.Itoa(i))
+				testBase.logger.Log("end " + string(rune(i)))
 				return err
 			})
 		}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently `go build` will return: 
```conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)```

This is due to the `vet` change in Go 1.15

> The vet tool now warns about conversions of the form string(x) where x has an integer type other than rune or byte. Experience with Go has shown that many conversions of this form erroneously assume that string(x) evaluates to the string representation of the integer x. It actually evaluates to a string containing the UTF-8 encoding of the value of x. For example, string(9786) does not evaluate to the string "9786"; it evaluates to the string "\xe2\x98\xba", or "☺".
> 
> Code that is using string(x) correctly can be rewritten to string(rune(x)). Or, in some cases, calling utf8.EncodeRune(buf, x) with a suitable byte slice buf may be the right solution. Other code should most likely use strconv.Itoa or fmt.Sprint.

For more information: https://golang.org/doc/go1.15


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
