### PR TITLE
Update driver version in communicator.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.1 (2020-10-27)
+
+* Fixed the dates in this CHANGELOG.md file
+* Updated the driver version in the user agent string to 1.0.1.
+
 # 1.0.0 (2020-10-20)
 
 The release candidate (v1.0.0-rc.1) has been selected as a final release of v1.0.0 with the following change:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [Accessing Amazon QLDB](https://docs.aws.amazon.com/qldb/latest/developergui
 
 ### Required Golang versions
 
-qldbdriver 1.0.0 requires Golang 1.14 or later.
+qldbdriver 1.0.1 requires Golang 1.14 or later.
 
 Please see the link below for more detail to install Golang:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [Accessing Amazon QLDB](https://docs.aws.amazon.com/qldb/latest/developergui
 
 ### Required Golang versions
 
-QldbDriver 1.0.1 requires Golang 1.14 or later.
+QldbDriver 1.x requires Golang 1.14 or later.
 
 Please see the link below for more detail to install Golang:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [Accessing Amazon QLDB](https://docs.aws.amazon.com/qldb/latest/developergui
 
 ### Required Golang versions
 
-qldbdriver 1.0.1 requires Golang 1.14 or later.
+QldbDriver 1.0.1 requires Golang 1.14 or later.
 
 Please see the link below for more detail to install Golang:
 

--- a/qldbdriver/communicator.go
+++ b/qldbdriver/communicator.go
@@ -111,7 +111,7 @@ func (communicator *communicator) startTransaction(ctx context.Context) (*qldbse
 }
 
 func (communicator *communicator) sendCommand(ctx context.Context, command *qldbsession.SendCommandInput) (*qldbsession.SendCommandOutput, error) {
-	const version string = "0.1.0"
+	const version string = "1.0.0"
 	const userAgentString = "QLDB Driver for Golang v" + version
 	command.SetSessionToken(*communicator.sessionToken)
 	communicator.logger.logf(LogDebug, "%v", command)

--- a/qldbdriver/communicator.go
+++ b/qldbdriver/communicator.go
@@ -111,7 +111,7 @@ func (communicator *communicator) startTransaction(ctx context.Context) (*qldbse
 }
 
 func (communicator *communicator) sendCommand(ctx context.Context, command *qldbsession.SendCommandInput) (*qldbsession.SendCommandOutput, error) {
-	const version string = "1.0.0"
+	const version string = "1.0.1"
 	const userAgentString = "QLDB Driver for Golang v" + version
 	command.SetSessionToken(*communicator.sessionToken)
 	communicator.logger.logf(LogDebug, "%v", command)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The version in communicator sendCommand was set to 0.1.0, updated to reflect current driver version (1.0.1)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
