### PR TITLE
QLDBDriverAPI and Cursor Interfaces

### DIFF
--- a/qldbdriver/result.go
+++ b/qldbdriver/result.go
@@ -19,6 +19,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/qldbsession"
 )
 
+type Cursor interface {
+	Next(txn Transaction) bool
+	Err() error
+	GetCurrentData() []byte
+}
+
 // Result is a cursor over a result set from a QLDB statement.
 type Result struct {
 	ctx          context.Context

--- a/qldbdriver/transaction.go
+++ b/qldbdriver/transaction.go
@@ -25,9 +25,9 @@ import (
 // Transaction represents an active QLDB transaction.
 type Transaction interface {
 	// Execute a statement with any parameters within this transaction.
-	Execute(statement string, parameters ...interface{}) (*Result, error)
+	Execute(statement string, parameters ...interface{}) (Cursor, error)
 	// Buffer a Result into a BufferedResult to use outside the context of this transaction.
-	BufferResult(result *Result) (*BufferedResult, error)
+	BufferResult(result Cursor) (*BufferedResult, error)
 	// Abort the transaction, discarding any previous statement executions within this transaction.
 	Abort() error
 }
@@ -94,12 +94,12 @@ type transactionExecutor struct {
 }
 
 // Execute a statement with any parameters within this transaction.
-func (executor *transactionExecutor) Execute(statement string, parameters ...interface{}) (*Result, error) {
+func (executor *transactionExecutor) Execute(statement string, parameters ...interface{}) (Cursor, error) {
 	return executor.txn.execute(executor.ctx, statement, parameters...)
 }
 
 // Buffer a Result into a BufferedResult to use outside the context of this transaction.
-func (executor *transactionExecutor) BufferResult(result *Result) (*BufferedResult, error) {
+func (executor *transactionExecutor) BufferResult(result Cursor) (*BufferedResult, error) {
 	bufferedResults := make([][]byte, 0)
 	for result.Next(executor) {
 		bufferedResults = append(bufferedResults, result.GetCurrentData())

--- a/qldbdriver/transaction_test.go
+++ b/qldbdriver/transaction_test.go
@@ -145,9 +145,11 @@ func TestTransactionExecutor(t *testing.T) {
 			mockService.On("executeStatement", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockExecuteResult, nil)
 			mockTransaction.communicator = mockService
 
-			result, err := testExecutor.Execute("mockStatement", "mockParam1", "mockParam2")
+			cursor, err := testExecutor.Execute("mockStatement", "mockParam1", "mockParam2")
 			assert.NoError(t, err)
-			assert.NotNil(t, result)
+			assert.NotNil(t, cursor)
+			result, ok := cursor.(*Result)
+			assert.True(t, ok)
 			assert.Equal(t, mockTransaction.communicator, result.communicator)
 			assert.Equal(t, mockTransaction.id, result.txnID)
 			assert.Equal(t, &mockNextPageToken, result.pageToken)

--- a/qldbdriveriface/interface.go
+++ b/qldbdriveriface/interface.go
@@ -15,3 +15,4 @@ type QLDBDriverAPI interface {
 }
 
 var _ QLDBDriverAPI = (*qldbdriver.QLDBDriver)(nil)
+

--- a/qldbdriveriface/interface.go
+++ b/qldbdriveriface/interface.go
@@ -1,0 +1,17 @@
+// Package qldbdriveriface provides an interface to enable mocking the QLDBDriver
+// for testing your code.
+package qldbdriveriface
+
+import (
+	"context"
+	"github.com/awslabs/amazon-qldb-driver-go/qldbdriver"
+)
+
+type QLDBDriverAPI interface {
+	SetRetryPolicy(rp qldbdriver.RetryPolicy)
+	Execute(ctx context.Context, fn func(txn qldbdriver.Transaction) (interface{}, error)) (interface{}, error)
+	GetTableNames(ctx context.Context) ([]string, error)
+	Shutdown(ctx context.Context)
+}
+
+var _ QLDBDriverAPI = (*qldbdriver.QLDBDriver)(nil)


### PR DESCRIPTION
*Issue #:* #38

*Description of changes:*

This PR builds on #40 to make `Result` an implementation of a new `Cursor` interface.  With this in place, it is possible to mock the Transaction results for testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
