### PR TITLE
Use errors.As() to unwrap error before wrapping

### DIFF
--- a/qldbdriver/session.go
+++ b/qldbdriver/session.go
@@ -15,6 +15,7 @@ package qldbdriver
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"regexp"
 
@@ -54,7 +55,8 @@ func (session *session) execute(ctx context.Context, fn func(txn Transaction) (i
 }
 
 func (session *session) wrapError(ctx context.Context, err error, transID string) *txnError {
-	if awsErr, ok := err.(awserr.RequestFailure); ok {
+	var awsErr awserr.RequestFailure
+	if errors.As(err, &awsErr) {
 		switch awsErr.Code() {
 		case qldbsession.ErrCodeInvalidSessionException:
 			match := regex.MatchString(awsErr.Message())

--- a/qldbdriver/session_test.go
+++ b/qldbdriver/session_test.go
@@ -489,10 +489,14 @@ func TestSessionExecute(t *testing.T) {
 
 	t.Run("wrappedAWSErrorHandling", func(t *testing.T) {
 		mockSessionService := new(mockSessionService)
+		mockSessionService.On("abortTransaction", mock.Anything).Return(&mockAbortTransactionResult, errMock)
+
 		session := session{mockSessionService, mockLogger}
 
-		err := session.wrapError(context.Background(), fmt.Errorf("Wrapped error: %w", testOCC), mockTransactionID)
+		err := session.wrapError(context.Background(), fmt.Errorf("ordinary error"), mockTransactionID)
+		assert.Equal(t, "", err.message)
 
+		err = session.wrapError(context.Background(), fmt.Errorf("wrapped error: %w", testOCC), mockTransactionID)
 		assert.Equal(t, testOCC, err.err)
 		assert.True(t, err.canRetry)
 	})


### PR DESCRIPTION
Resolves https://github.com/awslabs/amazon-qldb-driver-go/issues/46

Uses [erros.As()](https://golang.org/pkg/errors/#As) to detect `awserr.RequestFailure` instead of a type conversion before wrapping the error.

This is useful for when the user does their own error wrapping in their transaction function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
