### PR TITLE
Protect QLDBDriver's QLDBSession from outside mutation

### DIFF
--- a/qldbdriver/qldbdriver_test.go
+++ b/qldbdriver/qldbdriver_test.go
@@ -112,18 +112,24 @@ func TestNew(t *testing.T) {
 			})
 		require.NoError(t, err)
 
+		driverQldbSession, ok := createdDriver.qldbSession.(*qldbsession.QLDBSession)
+		require.True(t, ok)
+
 		qldbSession.Client.Retryer = client.DefaultRetryer{}
 		qldbSession.Client.Config = aws.Config{}
 		qldbSession.Client.ClientInfo = metadata.ClientInfo{}
 		qldbSession.Client.Handlers = request.Handlers{}
 
-		driverQldbSession, ok := createdDriver.qldbSession.(*qldbsession.QLDBSession)
-		require.True(t, ok)
-
 		assert.NotEqual(t, qldbSession.Client.Retryer, driverQldbSession.Client.Retryer)
 		assert.NotEqual(t, qldbSession.Client.Config, driverQldbSession.Client.Config)
 		assert.NotEqual(t, qldbSession.Client.ClientInfo, driverQldbSession.Client.ClientInfo)
 		assert.NotEqual(t, qldbSession.Client.Handlers, driverQldbSession.Client.Handlers)
+
+		qldbSession.Client = nil
+		assert.NotNil(t, driverQldbSession.Client)
+
+		qldbSession = nil
+		assert.NotNil(t, driverQldbSession)
 	})
 }
 

--- a/qldbdriver/qldbdriver_test.go
+++ b/qldbdriver/qldbdriver_test.go
@@ -20,7 +20,11 @@ import (
 	"time"
 
 	"github.com/amzn/ion-go/ion"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/client/metadata"
+	"github.com/aws/aws-sdk-go/aws/request"
 	sdksession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/qldbsession"
 	"github.com/stretchr/testify/assert"
@@ -38,6 +42,26 @@ func TestNew(t *testing.T) {
 			func(options *DriverOptions) {
 				options.LoggerVerbosity = LogOff
 				options.MaxConcurrentTransactions = 0
+			})
+		assert.Error(t, err)
+	})
+
+	t.Run("Invalid QLDBSession error", func(t *testing.T) {
+		_, err := New(mockLedgerName,
+			nil,
+			func(options *DriverOptions) {
+				options.LoggerVerbosity = LogOff
+			})
+		assert.Error(t, err)
+
+		awsSession := sdksession.Must(sdksession.NewSession())
+		qldbSession := qldbsession.New(awsSession)
+		qldbSession.Client = nil
+
+		_, err = New(mockLedgerName,
+			qldbSession,
+			func(options *DriverOptions) {
+				options.LoggerVerbosity = LogOff
 			})
 		assert.Error(t, err)
 	})
@@ -60,8 +84,16 @@ func TestNew(t *testing.T) {
 		assert.Equal(t, createdDriver.retryPolicy.MaxRetryLimit, defaultRetry)
 		assert.Equal(t, createdDriver.isClosed, false)
 		assert.Equal(t, cap(createdDriver.sessionPool), defaultMaxConcurrentTransactions)
-		assert.Equal(t, createdDriver.qldbSession, qldbSession)
-		assert.Equal(t, 0, *qldbSession.Client.Config.MaxRetries)
+
+		driverQldbSession, ok := createdDriver.qldbSession.(*qldbsession.QLDBSession)
+		require.True(t, ok)
+
+		assert.Equal(t, qldbSession.Client.Retryer, driverQldbSession.Client.Retryer)
+		assert.Equal(t, qldbSession.Client.ClientInfo, driverQldbSession.Client.ClientInfo)
+
+		*qldbSession.Client.Config.MaxRetries = 0
+		assert.Equal(t, qldbSession.Client.Config, driverQldbSession.Client.Config)
+		assert.Equal(t, 0, *driverQldbSession.Client.Config.MaxRetries)
 	})
 
 	t.Run("Retry limit overflow handled", func(t *testing.T) {
@@ -78,6 +110,31 @@ func TestNew(t *testing.T) {
 			})
 		require.NoError(t, err)
 		assert.Equal(t, 65534, createdDriver.maxConcurrentTransactions)
+	})
+
+	t.Run("Protected against QLDBSession mutation", func(t *testing.T) {
+		awsSession := sdksession.Must(sdksession.NewSession())
+		qldbSession := qldbsession.New(awsSession)
+
+		createdDriver, err := New(mockLedgerName,
+			qldbSession,
+			func(options *DriverOptions) {
+				options.LoggerVerbosity = LogOff
+			})
+		require.NoError(t, err)
+
+		qldbSession.Client.Retryer = client.DefaultRetryer{}
+		qldbSession.Client.Config = aws.Config{}
+		qldbSession.Client.ClientInfo = metadata.ClientInfo{}
+		qldbSession.Client.Handlers = request.Handlers{}
+
+		driverQldbSession, ok := createdDriver.qldbSession.(*qldbsession.QLDBSession)
+		require.True(t, ok)
+
+		assert.NotEqual(t, qldbSession.Client.Retryer, driverQldbSession.Client.Retryer)
+		assert.NotEqual(t, qldbSession.Client.Config, driverQldbSession.Client.Config)
+		assert.NotEqual(t, qldbSession.Client.ClientInfo, driverQldbSession.Client.ClientInfo)
+		assert.NotEqual(t, qldbSession.Client.Handlers, driverQldbSession.Client.Handlers)
 	})
 }
 

--- a/qldbdriver/qldbdriver_test.go
+++ b/qldbdriver/qldbdriver_test.go
@@ -116,13 +116,15 @@ func TestNew(t *testing.T) {
 		require.True(t, ok)
 
 		qldbSession.Client.Retryer = client.DefaultRetryer{}
-		qldbSession.Client.Config = aws.Config{}
-		qldbSession.Client.ClientInfo = metadata.ClientInfo{}
-		qldbSession.Client.Handlers = request.Handlers{}
-
 		assert.NotEqual(t, qldbSession.Client.Retryer, driverQldbSession.Client.Retryer)
+
+		qldbSession.Client.Config = aws.Config{}
 		assert.NotEqual(t, qldbSession.Client.Config, driverQldbSession.Client.Config)
+
+		qldbSession.Client.ClientInfo = metadata.ClientInfo{}
 		assert.NotEqual(t, qldbSession.Client.ClientInfo, driverQldbSession.Client.ClientInfo)
+
+		qldbSession.Client.Handlers = request.Handlers{}
 		assert.NotEqual(t, qldbSession.Client.Handlers, driverQldbSession.Client.Handlers)
 
 		qldbSession.Client = nil

--- a/qldbdriver/qldbdriver_test.go
+++ b/qldbdriver/qldbdriver_test.go
@@ -53,17 +53,6 @@ func TestNew(t *testing.T) {
 				options.LoggerVerbosity = LogOff
 			})
 		assert.Error(t, err)
-
-		awsSession := sdksession.Must(sdksession.NewSession())
-		qldbSession := qldbsession.New(awsSession)
-		qldbSession.Client = nil
-
-		_, err = New(mockLedgerName,
-			qldbSession,
-			func(options *DriverOptions) {
-				options.LoggerVerbosity = LogOff
-			})
-		assert.Error(t, err)
 	})
 
 	t.Run("New default success", func(t *testing.T) {


### PR DESCRIPTION
Resolves https://github.com/awslabs/amazon-qldb-driver-go/issues/53

Currently our `QLDBDriver` constructor takes in a `*qldbsession.QLDBSession`. Since this is a pointer, the underlying value is vulnerable to potential mutation by the calling code.

ie.
```go
driverSession := AWSSession.Must(AWSSession.NewSession(aws.NewConfig().WithRegion("us-east-1")))
qldbSession := qldbsession.New(driverSession)

// Use qldbSession in constructor
driver, _ := New(ledgerName, qldbSession)

// Mutate underlying value
qldbSession.Client.Retryer = client.DefaultRetryer{}
qldbSession.Client.Config = aws.Config{}
qldbSession.Client.ClientInfo = metadata.ClientInfo{}
qldbSession.Client.Handlers = request.Handlers{}

// Now we are trying to execute with a compromised qldbSession
_, err := driver.Execute(context.Background(), func(txn Transaction) (interface{}, error) {
    return txn.Execute("CREATE TABLE testTable")
})
```

We protect ourselves from this vulnerability by using a copy of the `qldbSession` and `qldbSession.Client` rather than using the original passed in `qldbSession`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.