### PR TITLE
Expose transaction ID in Transaction interface

### DIFF
--- a/qldbdriver/statement_execution_test.go
+++ b/qldbdriver/statement_execution_test.go
@@ -942,6 +942,20 @@ func TestStatementExecutionIntegration(t *testing.T) {
 		assert.True(t, ok)
 	})
 
+	t.Run("Return Transaction ID after executing statement", func(t *testing.T) {
+		query := fmt.Sprintf("SELECT * FROM %s", testTableName)
+		txnId, err := qldbDriver.Execute(context.Background(), func(txn Transaction) (interface{}, error) {
+			_, err := txn.Execute(query)
+			if err != nil {
+				return nil, err
+			}
+
+			return txn.Id(), nil
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, txnId)
+	})
+
 	// teardown
 	qldbDriver.Shutdown(context.Background())
 	testBase.deleteLedger(t)

--- a/qldbdriver/statement_execution_test.go
+++ b/qldbdriver/statement_execution_test.go
@@ -944,16 +944,16 @@ func TestStatementExecutionIntegration(t *testing.T) {
 
 	t.Run("Return Transaction ID after executing statement", func(t *testing.T) {
 		query := fmt.Sprintf("SELECT * FROM %s", testTableName)
-		txnId, err := qldbDriver.Execute(context.Background(), func(txn Transaction) (interface{}, error) {
+		txnID, err := qldbDriver.Execute(context.Background(), func(txn Transaction) (interface{}, error) {
 			_, err := txn.Execute(query)
 			if err != nil {
 				return nil, err
 			}
 
-			return txn.Id(), nil
+			return txn.ID(), nil
 		})
 		require.NoError(t, err)
-		assert.NotEmpty(t, txnId)
+		assert.NotEmpty(t, txnID)
 	})
 
 	// teardown

--- a/qldbdriver/transaction.go
+++ b/qldbdriver/transaction.go
@@ -30,6 +30,8 @@ type Transaction interface {
 	BufferResult(res Result) (BufferedResult, error)
 	// Abort the transaction, discarding any previous statement executions within this transaction.
 	Abort() error
+	// Return the transaction ID.
+	Id() string
 }
 
 type transaction struct {
@@ -127,4 +129,9 @@ func (executor *transactionExecutor) BufferResult(result Result) (BufferedResult
 // Abort the transaction, discarding any previous statement executions within this transaction.
 func (executor *transactionExecutor) Abort() error {
 	return errors.New("transaction aborted")
+}
+
+// Return the transaction ID.
+func (executor *transactionExecutor) Id() string {
+	return *executor.txn.id
 }

--- a/qldbdriver/transaction.go
+++ b/qldbdriver/transaction.go
@@ -31,7 +31,7 @@ type Transaction interface {
 	// Abort the transaction, discarding any previous statement executions within this transaction.
 	Abort() error
 	// Return the transaction ID.
-	Id() string
+	ID() string
 }
 
 type transaction struct {
@@ -132,6 +132,6 @@ func (executor *transactionExecutor) Abort() error {
 }
 
 // Return the transaction ID.
-func (executor *transactionExecutor) Id() string {
+func (executor *transactionExecutor) ID() string {
 	return *executor.txn.id
 }

--- a/qldbdriver/transaction_test.go
+++ b/qldbdriver/transaction_test.go
@@ -321,7 +321,7 @@ func TestTransactionExecutor(t *testing.T) {
 
 	t.Run("Transaction ID", func(t *testing.T) {
 		id := testExecutor.ID()
-		assert.NotEmpty(t, id)
+		assert.Equal(t, mockID, id)
 	})
 }
 

--- a/qldbdriver/transaction_test.go
+++ b/qldbdriver/transaction_test.go
@@ -320,7 +320,7 @@ func TestTransactionExecutor(t *testing.T) {
 	})
 
 	t.Run("Transaction ID", func(t *testing.T) {
-		id := testExecutor.Id()
+		id := testExecutor.ID()
 		assert.NotEmpty(t, id)
 	})
 }

--- a/qldbdriver/transaction_test.go
+++ b/qldbdriver/transaction_test.go
@@ -318,6 +318,11 @@ func TestTransactionExecutor(t *testing.T) {
 		abort := testExecutor.Abort()
 		assert.Error(t, abort)
 	})
+
+	t.Run("Transaction ID", func(t *testing.T) {
+		id := testExecutor.Id()
+		assert.NotEmpty(t, id)
+	})
 }
 
 type mockTransactionService struct {


### PR DESCRIPTION
Resolves https://github.com/awslabs/amazon-qldb-driver-go/issues/57.

This PR allows users to access the transaction ID within a lambda execute function like so:

```go
txnID, err := qldbDriver.Execute(context.Background(), func(txn Transaction) (interface{}, error) {
	_, err := txn.Execute(query)
	if err != nil {
		return nil, err
	}

	return txn.ID(), nil
})
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
