### PR TITLE
correctly implement backoff full jitter

### DIFF
--- a/qldbdriver/retry.go
+++ b/qldbdriver/retry.go
@@ -48,5 +48,5 @@ func (s ExponentialBackoffStrategy) Delay(retryAttempt int) time.Duration {
 	rand.Seed(time.Now().UTC().UnixNano())
 	jitter := rand.Float64()*0.5 + 0.5
 
-	return time.Duration(jitter*math.Min(float64(s.SleepCap.Milliseconds()), math.Pow(float64(s.SleepBase.Milliseconds()), float64(retryAttempt)))) * time.Millisecond
+	return time.Duration(jitter*math.Min(float64(s.SleepCap.Milliseconds()), float64(s.SleepBase.Milliseconds())*math.Pow(2, float64(retryAttempt)))) * time.Millisecond
 }


### PR DESCRIPTION
*Issue #121*

*Description of changes:*
the jitter backoff math should random with base_sleep * 2** retryCount. NOT base_sleep ** retryCount. The implication is that every retry after the 2nd retry, will add nearly 3s of delay to the retry sequence, if theres db contention.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
