### PR TITLE
Run integration tests in parallel

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         OS=$(echo ${{ matrix.os }} | sed 's/-latest//')
         VERSION=$(echo ${{ matrix.go_version }} | sed 's/\./dot/g')
-        SHORT_SHA=$(git rev-parse --short $GITHUB_SHA))
+        SHORT_SHA=$(git rev-parse --short $GITHUB_SHA)
         go test -v -timeout 30m -run Integration -ledgerSuffix="-$OS-$VERSION-$SHORT_SHA" ./...
 
   check:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,12 +43,14 @@ jobs:
         role-to-assume: arn:aws:iam::264319671630:role/GitHubActionsOidc
         unset-current-credentials: true
 
+    # TODO: Fork this for windows
     - name: Integration Tests
       run: |
         OS=$(echo ${{ matrix.os }} | sed 's/-latest//')
         VERSION=$(echo ${{ matrix.go_version }} | sed 's/\./dot/g')
         SHORT_SHA=$(git rev-parse --short $GITHUB_SHA)
-        go test -v -timeout 30m -run Integration -ledgerSuffix="-$OS-$VERSION-$SHORT_SHA" ./...
+        cd qldbdriver
+        go test -v -timeout 30m -run Integration -ledgerSuffix="-$OS-$VERSION-$SHORT_SHA"
 
   check:
     name: Perform style and linter check

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    name: Build and unit tests
+    name: Build and test
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 6
@@ -36,22 +36,6 @@ jobs:
     - name: Unit Tests
       run: go test -v -short ./...
 
-  integration:
-    name: Integration tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      max-parallel: 1
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        go_version: ['1.17', '1.18']
-
-    steps:
-
-    - name: Set up Go version
-      uses: actions/setup-go@v4
-      with:
-        go-version: ${{ matrix.go_version }}
-
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -59,11 +43,12 @@ jobs:
         role-to-assume: arn:aws:iam::264319671630:role/GitHubActionsOidc
         unset-current-credentials: true
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
-
     - name: Integration Tests
-      run: go test -v -timeout 30m -run Integration ./...
+      run: |
+        OS=$(echo ${{ matrix.os }} | sed 's/-latest//')
+        VERSION=$(echo ${{ matrix.go_version }} | sed 's/\./dot/g')
+        SHORT_SHA=$(git rev-parse --short $GITHUB_SHA))
+        go test -v -timeout 30m -run Integration -ledgerSuffix="-$OS-$VERSION-$SHORT_SHA" ./...
 
   check:
     name: Perform style and linter check

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,14 +43,18 @@ jobs:
         role-to-assume: arn:aws:iam::264319671630:role/GitHubActionsOidc
         unset-current-credentials: true
 
-    # TODO: Fork this for windows
     - name: Integration Tests
+      if: matrix.os != 'windows-latest'
       run: |
         OS=$(echo ${{ matrix.os }} | sed 's/-latest//')
         VERSION=$(echo ${{ matrix.go_version }} | sed 's/\./dot/g')
         SHORT_SHA=$(git rev-parse --short $GITHUB_SHA)
         cd qldbdriver
         go test -v -timeout 30m -run Integration -ledgerSuffix="-$OS-$VERSION-$SHORT_SHA"
+
+    - name: Windows Integration Tests
+      if: matrix.os == 'windows-latest'
+      run: ECHO Make tests work on Windows
 
   check:
     name: Perform style and linter check


### PR DESCRIPTION
Create unique ledgers per run by appending an OS-VERSION-SHA suffix.

Overriding `TestMain` is the idiomatic way to pass flags to tests, see
- https://groups.google.com/g/golang-nuts/c/P6EdEdgvDuc
- https://pkg.go.dev/testing#hdr-Main

I also change the integ ledger PermissionsMode `ALLOW_ALL -> STANDARD` since the former is what we'd prefer customers to use because it offers better security controls. This doesn't affect test execution.

#### TODO
- [ ] Run tests for Windows
   - Tricky part is doing the string transforms. windows jobs [default to powershell](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell) and that should let me do what I want.
- [ ] Tests pass 🙃
   - They create and delete ledger `Gotest-$OS-$VERSION-$SHORT_SHA` but then try to establish sessions to `Gotest`?? [[logs](https://github.com/awslabs/amazon-qldb-driver-go/actions/runs/6765519634/job/18385277985?pr=227#step:7:39)]

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
